### PR TITLE
Added support for using remote Redis instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.pyc
+*.pyo
+.DS_Store
+*.rdb
+build
+dist
+*.egg-info
+

--- a/README.rst
+++ b/README.rst
@@ -41,13 +41,24 @@ Each of the types provided by HOT Redis strive to implement the same method sign
     >>> my_list_with_key.key
     'foo'
 
+Note that, by default, HOT Redis attempts to connect to a Redis instance running locally on the default port 6379. If you wish to use a Redis instance on another host, port, or database number, you will have to explicitly create a HotClient instance and pass the client to each HOT Redis type you instantiate::
+
+    >>> from hot_redis import HotClient, Queue
+    >>> client = HotClient(host='myremotehost', port=6380)
+    >>> my_queue = Queue(client=client)
+    >>> my_queue.key
+    'ff2479f3-d949-4c0c-ad28-0b052e75d7d1'
+    >>> my_queue.put('Hello, world!')
+    >>> my_queue.get()
+    'Hello, world!'
+
 Once you've determined a strategy for naming keys, you can then create HOT Redis objects and interact with them over the network, for example here is a ``List`` created on a computer we'll refer to as computer A::
 
-    >>> list_on_computer_a = List(key="foo", initial=["a", "b", "c"])
+    >>> list_on_computer_a = List(key="foo", initial=["a", "b", "c"], client=client)
 
 then on another computer we'll creatively refer to as computer B::
 
-    >>> list_on_computer_b = List(key="foo")
+    >>> list_on_computer_b = List(key="foo", client=client)
     >>> list_on_computer_b[:]  # Performs: LRANGE foo 0 -1
     ['a', 'b', 'c']
     >>> list_on_computer_b += ['d', 'e', 'f']  # Performs: RPUSH foo d e f


### PR DESCRIPTION
The previous version worked fine with a local Redis instance running on the default port/db, but there was no obvious way to specify a remote Redis instance of use non-default parameters.  This patch is fully backwards-compatible, but allows users to pass a HotClient instance (with any Redis connection parameters) to HOT Redis types using the "client" keyword.  A .gitignore file has been added to mirror the .hgignore.  Documentation has also been updated for the patch.
