### PR TITLE
keyword argument for client.configure

### DIFF
--- a/hot_redis/client.py
+++ b/hot_redis/client.py
@@ -69,7 +69,7 @@ def default_client():
     return _thread.client
 
 
-def configure(config):
+def configure(**config):
     global _config
     _config = config
 


### PR DESCRIPTION
Let client.configure use the keyword arguments. Just like the usage of configuration in readme file at line 111.