### PR TITLE
Fixing collections.abc DeprecationWarning

### DIFF
--- a/hot_redis/types.py
+++ b/hot_redis/types.py
@@ -1,5 +1,4 @@
 
-import collections
 import operator
 import time
 import uuid
@@ -8,9 +7,12 @@ try:
     # Python 3.
     import queue
     from functools import reduce
+    from collections import Counter
+    from collections.abc import MutableMapping
 except ImportError:
     # Python 2.
     import Queue as queue
+    from collections import MutableMapping, Counter
 
 import redis
 
@@ -825,7 +827,7 @@ class MultiSet(Dict):
     def value(self):
         value = super(MultiSet, self).value
         kwargs = dict([(k, int(v)) for k, v in value.items()])
-        return collections.Counter(**kwargs)
+        return Counter(**kwargs)
 
     __add__  = op_left(operator.add)
     __sub__  = op_left(operator.sub)
@@ -916,4 +918,4 @@ class MultiSet(Dict):
             values = values[:n]
         return values
 
-collections.abc.MutableMapping.register(MultiSet)
+MutableMapping.register(MultiSet)

--- a/hot_redis/types.py
+++ b/hot_redis/types.py
@@ -916,4 +916,4 @@ class MultiSet(Dict):
             values = values[:n]
         return values
 
-collections.MutableMapping.register(MultiSet)
+collections.abc.MutableMapping.register(MultiSet)


### PR DESCRIPTION
That will help hot-redis support python 3.9

```
/hot-redis/hot_redis/types.py:919: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    collections.MutableMapping.register(MultiSet)
```