### PR TITLE
Added support for Python3.10 by updating collections references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
   - "3.4"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 services: redis-server
 install: pip install .
 script: python setup.py test

--- a/hot_redis/types.py
+++ b/hot_redis/types.py
@@ -916,4 +916,4 @@ class MultiSet(Dict):
             values = values[:n]
         return values
 
-collections.MutableMapping.register(MultiSet)
+collections.abc.MutableMapping.register(MultiSet)


### PR DESCRIPTION
Collections has dropped support for importing abstract classes directly from collections and added them to collections.abc
These changes are compatible across python 3.3 to 3.10+.